### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -234,6 +234,7 @@ jobs:
 
   results:
     name: Test Results Summary
+    permissions: {}
     runs-on: ubuntu-latest
     needs: [lint, test-unit, test-integration, coverage, security]
     if: always()


### PR DESCRIPTION
Potential fix for [https://github.com/VEUKA/streamduck/security/code-scanning/9](https://github.com/VEUKA/streamduck/security/code-scanning/9)

To fix the problem, add an explicit `permissions` block for the "results" job. The minimal permissions required should be set. Since this job only outputs results and creates a step summary (which does not need any token privileges), the most restrictive possible setting would be to set `permissions: {}`. If in the future the job needs to use GITHUB_TOKEN for any read-only operation, use `contents: read`. For now, adding `permissions: {}` just below `name: Test Results Summary` and above `runs-on: ...` in the "results" job accomplishes the fix without impacting functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
