### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -169,6 +169,8 @@ jobs:
 
   security:
     name: Security Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/VEUKA/streamduck/security/code-scanning/8](https://github.com/VEUKA/streamduck/security/code-scanning/8)

The recommended fix is to explicitly declare a minimal `permissions:` block for the `security` job within `.github/workflows/ci-cd.yml`. All the steps in the `security` job read from the repository and upload an artifact; none require write access to repository code, so the minimal setting of `contents: read` is sufficient. The change should be made right under `name: Security Scan` (line 171) and before `runs-on:` so that only this job’s permissions are affected and no functionality is changed. No external imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
